### PR TITLE
correct string match  for M1 camera detection - "StartStream: Powering ON camera"

### DIFF
--- a/Application/Application/AVMonitor.m
+++ b/Application/Application/AVMonitor.m
@@ -208,7 +208,7 @@ extern os_log_t logHandle;
         
         //camera on
         // show alert!
-        else if(YES == [logEvent.composedMessage isEqualToString:@"StartStream : StartStream: Powering ON camera"])
+        else if(YES == [logEvent.composedMessage isEqualToString:@"StartStream: Powering ON camera"])
         {
             //event
             Event* event = nil;


### PR DESCRIPTION
Macbook Air (2020, M1)

OverSight does not display a notification when camera is activated, e.g. in Zoom => Settings => Video preview

Detection of M1 camera is via string match:

https://github.com/objective-see/OverSight/blob/680dd2cc70e8ef590f93212bd1d1ae9e1bc0b93b/Application/Application/AVMonitor.m#L209-L211

But the match string has an extraneous `StartStream : ` prefix and is not matched, as shown by lack of `camera on msg` line in `log stream --debug --predicate 'process=="appleh13camerad" or subsystem="com.objective-see.oversight"'`

```
2021-12-29 12:04:25.698364-0800 0x22c97    Default     0x0                  743    0    appleh13camerad: StartStream: Powering ON camera
2021-12-29 12:04:25.698388-0800 0x22c97    Info        0x0                  743    0    appleh13camerad: PowerOnCamera
2021-12-29 12:04:25.699297-0800 0x22a53    Debug       0x0                  11689  0    OverSight: [com.objective-see.oversight:application] new (video) client msg: TCC access already allowed for pid 11676
2021-12-29 12:04:25.700581-0800 0x22a53    Debug       0x0                  11689  0    OverSight: [com.objective-see.oversight:application] new (video) client: CLIENT: pid: 11676, path: /Applications/zoom.us.app/Contents/MacOS/zoom.us, clientID: (null)
2021-12-29 12:04:25.709128-0800 0x1865     Info        0x0                  743    0    appleh13camerad: MyH13ISPDeviceMessageNotification - Unknown messageType = 0xe0000215
2021-12-29 12:04:26.743272-0800 0x1865     Info        0x0                  743    0    appleh13camerad: MyH13ISPDeviceMessageNotification - Unknown messageType = 0xe0000130
2021-12-29 12:04:26.743381-0800 0x1865     Info        0x0                  743    0    appleh13camerad: MyH13ISPDeviceMessageNotification - kIOMessageDeviceHasPoweredOn
2021-12-29 12:04:26.744135-0800 0x22c97    Default     0x0                  743    0    appleh13camerad: H13ISPDEVICE:: This isn't an internal build, and FDR wasn't validated
2021-12-29 12:04:26.744436-0800 0x22c97    Default     0x0                  743    0    appleh13camerad: PowerOnCamera : ISP_PowerOnCamera: powered on camera
```

With this PR, log output includes a `camera on msg` indicating a match

```
2021-12-29 11:47:33.610593-0800 0x1fdd0    Default     0x0                  743    0    appleh13camerad: StartStream: Powering ON camera
2021-12-29 11:47:33.610602-0800 0x1fdd0    Info        0x0                  743    0    appleh13camerad: PowerOnCamera
2021-12-29 11:47:33.610610-0800 0x1fdd0    Default     0x0                  743    0    appleh13camerad: PowerOnCamera : Camera is already ON, returning
2021-12-29 11:47:33.611274-0800 0x1fcf0    Debug       0x0                  11415  0    OverSight: [com.objective-see.oversight:application] new (video) client: CLIENT: pid: 10819, path: /Applications/zoom.us.app/Contents/MacOS/zoom.us, clientID: (null)
2021-12-29 11:47:33.610665-0800 0x1865     Info        0x0                  743    0    appleh13camerad: MyH13ISPDeviceMessageNotification - Unknown messageType = 0x21726573
2021-12-29 11:47:33.610768-0800 0x1865     Info        0x0                  743    0    appleh13camerad: MyH13ISPDeviceMessageNotification - Unknown messageType = 0xe0000130
2021-12-29 11:47:33.611403-0800 0x1fcf0    Debug       0x0                  11415  0    OverSight: [com.objective-see.oversight:application] camera on msg: StartStream: Powering ON camera
```

and a notification is correctly displayed

<img width="378" alt="image" src="https://user-images.githubusercontent.com/60824/147699332-93b0efb2-0cec-41d5-935c-c3ccfda1ccd2.png">
