### PR TITLE
Pass active device count.

### DIFF
--- a/Application/Application/AVMonitor.m
+++ b/Application/Application/AVMonitor.m
@@ -1525,6 +1525,10 @@ bail:
             [args addObject:@"-process"];
             [args addObject:event.client.pid.stringValue];
         }
+        
+        //add active device count
+        [args addObject:@"-activeCount"];
+        [args addObject:[NSNumber numberWithUnsignedLong:[self enumerateActiveDevices].count]];
     }
     
     //exec user specified action

--- a/Application/Application/Preferences.xib
+++ b/Application/Application/Preferences.xib
@@ -27,7 +27,7 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="196" y="240" width="600" height="426"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="600" height="426"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -256,16 +256,6 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="471" translatesAutoresizingMaskIntoConstraints="NO" id="GP0-UX-66J">
-                    <rect key="frame" x="72" y="84" width="510" height="60"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="7Ah-kZ-gGe">
-                        <font key="font" size="13" name="Menlo-Regular"/>
-                        <string key="title">OverSight will pass in the following arguments: -device &lt;camera|microphone&gt; -event &lt;on|off&gt; -process &lt;pid&gt;  Note: -process is only specified on activation events.</string>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <textField verticalHuggingPriority="750" fixedFrame="YES" preferredMaxLayoutWidth="382" translatesAutoresizingMaskIntoConstraints="NO" id="z32-0s-dpb">
                     <rect key="frame" x="143" y="223" width="437" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -297,6 +287,18 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Execute a script or binary when an event is detected." id="bky-MW-yBn">
                         <font key="font" size="13" name="Menlo-Regular"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="471" translatesAutoresizingMaskIntoConstraints="NO" id="GP0-UX-66J">
+                    <rect key="frame" x="72" y="39" width="510" height="105"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="7Ah-kZ-gGe">
+                        <font key="font" size="13" name="Menlo-Regular"/>
+                        <string key="title">OverSight will pass in the following arguments: -device &lt;camera|microphone&gt; -event &lt;on|off&gt; -process &lt;pid&gt; -activeCount &lt;0..n&gt;  Notes:
+-process is only specified on activation events.
+-activeCount is the number of devices still active.</string>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>


### PR DESCRIPTION
When running a script it would be helpful to know if there are still any active devices. This gives the user more information to determine what they want to perform in their script.

Example: I want to turn on a smart switch when my camera or mic are active. This switch has a usb 'On Air' light plugged into it. I don't want the light to turn off until all devices are no longer active. The active count allows me to check without having to keep track since Oversight already does this.

Note: I tried to run this locally but had issues with the Sentry framework. Some instruction on how to build locally would be helpful so I'm not making useless PRs.